### PR TITLE
fix resume button

### DIFF
--- a/src/Pages/BouncingBall.elm
+++ b/src/Pages/BouncingBall.elm
@@ -255,7 +255,7 @@ computeNextPos model =
                         }
                 in
                 ( nextPos
-                , nextPos :: hist
+                , List.append model.hist [ nextPos ]
                 , frameNo + 1
                 )
 
@@ -266,7 +266,7 @@ computeNextPos model =
                     Just pos_ ->
                         ( pos_
                         , hist
-                        , frameNo
+                        , frameNo + 1
                         )
 
                     Nothing ->
@@ -281,7 +281,7 @@ update msg model =
             ( { model
                 | currentFrame = round val
                 , ballPos =
-                    case List.Extra.getAt (List.length model.hist - round val) model.hist of
+                    case List.Extra.getAt (round val) model.hist of
                         Just pos_ ->
                             pos_
 
@@ -312,7 +312,22 @@ update msg model =
         UserToggledPause ->
             case model.runningState of
                 Paused ->
-                    ( { model | runningState = Playing }, Effect.none )
+                    let
+                        nextPos : Pos
+                        nextPos =
+                            case List.Extra.getAt model.currentFrame model.hist of
+                                Just pos_ ->
+                                    pos_
+
+                                Nothing ->
+                                    defaultPos
+                    in
+                    ( { model
+                        | runningState = Playing
+                        , ballPos = nextPos
+                      }
+                    , Effect.none
+                    )
 
                 Playing ->
                     ( { model | runningState = Paused }, Effect.none )

--- a/src/Pages/BouncingBall.elm
+++ b/src/Pages/BouncingBall.elm
@@ -312,22 +312,7 @@ update msg model =
         UserToggledPause ->
             case model.runningState of
                 Paused ->
-                    let
-                        nextPos : Pos
-                        nextPos =
-                            case List.Extra.getAt model.currentFrame model.hist of
-                                Just pos_ ->
-                                    pos_
-
-                                Nothing ->
-                                    defaultPos
-                    in
-                    ( { model
-                        | runningState = Playing
-                        , ballPos = nextPos
-                      }
-                    , Effect.none
-                    )
+                    ( { model | runningState = Playing }, Effect.none )
 
                 Playing ->
                     ( { model | runningState = Paused }, Effect.none )

--- a/tests/BouncingBallTest.elm
+++ b/tests/BouncingBallTest.elm
@@ -1,5 +1,6 @@
-module Array2DTest exposing (..)
+module BouncingBallTest exposing (..)
 
+import Expect
 import Test exposing (..)
 
 
@@ -7,5 +8,10 @@ suite : Test
 suite =
     describe "Bouncing ball app"
         [ describe "Play/pause resume logic"
-            []
+            [ test "TODO: Add tests!"
+                (\_ ->
+                    10
+                        |> Expect.equal 10
+                )
+            ]
         ]

--- a/tests/BouncingBallTest.elm
+++ b/tests/BouncingBallTest.elm
@@ -1,0 +1,11 @@
+module Array2DTest exposing (..)
+
+import Test exposing (..)
+
+
+suite : Test
+suite =
+    describe "Bouncing ball app"
+        [ describe "Play/pause resume logic"
+            []
+        ]


### PR DESCRIPTION
The resume feature is broken. That is, upon clicking “play” after time traveling, the animation should continue at the frame that was selected by moving the slider. In the event that the most recent frame was selected, the simulation should continue as-it-were. If the frame selected is not the most recent, the animation should continue from history until it has reached the most recent frame. Upon reaching the frame after the most recent, the simulation should seamlessly transition from historic recall to live-simulation.