### PR TITLE
Bball interventions

### DIFF
--- a/src/Pages/BouncingBall.elm
+++ b/src/Pages/BouncingBall.elm
@@ -176,8 +176,10 @@ type Msg
     | UserClickedRefresh
     | UserToggledPause
     | TimelineSliderSlidTo Float
+    | ProposeIntervention
 
 
+epsilon : Float
 epsilon =
     -- '-3' is  'mm'
     1.0e-4
@@ -277,6 +279,28 @@ computeNextPos model =
 update : Msg -> Model -> ( Model, Effect Msg )
 update msg model =
     case msg of
+        ProposeIntervention ->
+            let
+                pos : Pos
+                pos =
+                    model.ballPos
+
+                newPos : Pos
+                newPos =
+                    { pos | vx = -1 * model.ballPos.vx }
+
+                newHist : List Pos
+                newHist =
+                    List.take model.currentFrame model.hist
+            in
+            ( { model
+                | ballPos = newPos
+                , runningState = Playing
+                , hist = newHist
+              }
+            , Effect.none
+            )
+
         TimelineSliderSlidTo val ->
             ( { model
                 | currentFrame = round val
@@ -510,6 +534,12 @@ viewDebugPanel model =
         , E.text <| "r_y (m): " ++ String.fromFloat model.ballPos.ry
         , E.text <| "current frame: " ++ String.fromInt model.currentFrame
         , E.text <| "running state: " ++ runState2Str model.runningState
+        , el
+            [ alignBottom
+            , centerX
+            , Events.onClick ProposeIntervention
+            ]
+            (text "Intervene!")
         ]
 
 

--- a/tests/BouncingBallTest.elm
+++ b/tests/BouncingBallTest.elm
@@ -14,7 +14,7 @@ suite =
                     computeNextPos case1
                         |> Expect.equal ( case1.ballPos, case1.hist, case1.currentFrame )
                 )
-            , test "simulation is playing, no historic recalld"
+            , test "simulation is playing, no historic recall"
                 (\_ ->
                     computeNextPos case2
                         |> Expect.equal ( { rx = 1, ry = 1.725, vx = 1, vy = -1.488, x = 10.033333333333333, y = 9.9504 }, [ { rx = 1, ry = 1, vx = 1, vy = 1, x = 9, y = 11 }, { rx = 1, ry = 1.725, vx = 1, vy = -1.488, x = 10.033333333333333, y = 9.9504 } ], 2 )
@@ -26,16 +26,6 @@ suite =
                 )
             ]
         ]
-
-
-
--- cases:
--- state is paused
---
--- state is playing, and is at new frames are to be simulated
---
--- state is playing, and next frame is to be recalled from history
---
 
 
 case1 : Model


### PR DESCRIPTION
- When paused (either via the pause button or time-travel slider), the user may override a value in the debug panel. This becomes the “true” state when the simulation is resumed.
- For now, when the user intervenes the future always changes according to that intervention. Meaning, after time travel, history should reflect the original simulation up until the instant of intervention, which should then become the “real” history